### PR TITLE
Tmp fix for bug with duplicated test names

### DIFF
--- a/result_companion/core/html/html_creator.py
+++ b/result_companion/core/html/html_creator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import markdown
 
-from result_companion.core.html.robot_writers_inheritance import (
+from result_companion.core.html.result_writer import (
     create_base_llm_result_log,
 )
 

--- a/result_companion/core/html/html_creator.py
+++ b/result_companion/core/html/html_creator.py
@@ -2,9 +2,7 @@ from pathlib import Path
 
 import markdown
 
-from result_companion.core.html.result_writer import (
-    create_base_llm_result_log,
-)
+from result_companion.core.html.result_writer import create_base_llm_result_log
 
 
 def _escape_multilines_in_html(html: str) -> str:

--- a/result_companion/core/html/result_writer.py
+++ b/result_companion/core/html/result_writer.py
@@ -8,6 +8,8 @@ from robot.reporting.logreportwriters import LogWriter, RobotModelWriter
 from robot.reporting.resultwriter import Results, ResultWriter
 from robot.utils import file_writer
 
+from result_companion.core.results.visitors import UniqueNameResultVisitor
+
 LLM_LOG = Path(__file__).parent / "templates" / "llm_template.html"
 
 
@@ -74,6 +76,7 @@ def create_base_llm_result_log(
     input_result_path: "Path|str", llm_output_path: "Path|str"
 ):
     results = ExecutionResult(input_result_path)
+    results.visit(UniqueNameResultVisitor())
     writer = LLMResultWriter(results)
     with patch("robot.htmldata.htmlfilewriter.HtmlTemplate", new=LLMHtmlTemplate):
         writer.write_results(report=None, log=llm_output_path, xunit=None)

--- a/result_companion/core/parsers/result_parser.py
+++ b/result_companion/core/parsers/result_parser.py
@@ -1,8 +1,8 @@
-import uuid
 from pathlib import Path
 
-from robot.api import ExecutionResult, ResultVisitor
+from robot.api import ExecutionResult
 
+from result_companion.core.results.visitors import UniqueNameResultVisitor
 from result_companion.core.utils.log_levels import LogLevels
 from result_companion.core.utils.logging_config import logger
 
@@ -62,37 +62,13 @@ def remove_redundant_fields(data: list[dict]) -> list[dict]:
     return data
 
 
-# TODO: workaround to fix potentail problem with exposing llm results to invalid test cases in log.html
-def add_unique_sufix_for_test_cases_with_duplicated_names(
-    data: list[dict], random_sufix: str | None = None
-) -> list[dict]:
-    all_test_cases_names = [test_case["name"] for test_case in data]
-    unique_test_cases = set(all_test_cases_names)
-    all_duplicated_test_cases_names = [
-        test_case_name
-        for test_case_name in all_test_cases_names
-        if all_test_cases_names.count(test_case_name) > 1
-    ]
-
-    if len(unique_test_cases) == len(all_test_cases_names):
-        return data
-
-    for test_case in data:
-        if test_case["name"] in all_duplicated_test_cases_names:
-            if not random_sufix:
-                random_sufix = str(uuid.uuid4())
-            test_case["name"] = f"{test_case['name']}_{random_sufix}"
-    return data
-
-
 def get_robot_results_from_file_as_dict(
     file_path: Path, log_level: LogLevels
 ) -> list[dict]:
     logger.debug(f"Getting robot results from {file_path}")
     result = ExecutionResult(file_path)
-    result.visit(ResultVisitor())
+    result.visit(UniqueNameResultVisitor())
     all_results = result.suite.to_dict()
     all_results = search_for_test_caseses(all_results)
     all_results = remove_redundant_fields(all_results)
-    all_results = add_unique_sufix_for_test_cases_with_duplicated_names(all_results)
     return all_results

--- a/result_companion/core/parsers/result_parser.py
+++ b/result_companion/core/parsers/result_parser.py
@@ -1,3 +1,4 @@
+import uuid
 from pathlib import Path
 
 from robot.api import ExecutionResult, ResultVisitor
@@ -61,6 +62,29 @@ def remove_redundant_fields(data: list[dict]) -> list[dict]:
     return data
 
 
+# TODO: workaround to fix potentail problem with exposing llm results to invalid test cases in log.html
+def add_unique_sufix_for_test_cases_with_duplicated_names(
+    data: list[dict], random_sufix: str | None = None
+) -> list[dict]:
+    all_test_cases_names = [test_case["name"] for test_case in data]
+    unique_test_cases = set(all_test_cases_names)
+    all_duplicated_test_cases_names = [
+        test_case_name
+        for test_case_name in all_test_cases_names
+        if all_test_cases_names.count(test_case_name) > 1
+    ]
+
+    if len(unique_test_cases) == len(all_test_cases_names):
+        return data
+
+    for test_case in data:
+        if test_case["name"] in all_duplicated_test_cases_names:
+            if not random_sufix:
+                random_sufix = str(uuid.uuid4())
+            test_case["name"] = f"{test_case['name']}_{random_sufix}"
+    return data
+
+
 def get_robot_results_from_file_as_dict(
     file_path: Path, log_level: LogLevels
 ) -> list[dict]:
@@ -70,4 +94,5 @@ def get_robot_results_from_file_as_dict(
     all_results = result.suite.to_dict()
     all_results = search_for_test_caseses(all_results)
     all_results = remove_redundant_fields(all_results)
+    all_results = add_unique_sufix_for_test_cases_with_duplicated_names(all_results)
     return all_results

--- a/result_companion/core/results/visitors.py
+++ b/result_companion/core/results/visitors.py
@@ -1,0 +1,34 @@
+from robot.api import ResultVisitor
+
+from result_companion.core.utils.logging_config import logger
+
+
+# TODO: workaround to fix potentail problem with exposing llm results to invalid test cases in log.html
+class UniqueNameResultVisitor(ResultVisitor):
+    """Custom visitor that ensures unique test case names by appending IDs to duplicates."""
+
+    def __init__(self):
+        super().__init__()
+        self.test_names = {}
+
+    def start_test(self, test):
+        """Called when a test is encountered during traversal."""
+        if test.name in self.test_names:
+            self.test_names[test.name] += 1
+        else:
+            self.test_names[test.name] = 1
+
+    def end_suite(self, suite):
+        """Called when suite processing is complete."""
+        for test in suite.tests:
+            if test.name in self.test_names and self.test_names[test.name] > 1:
+                logger.debug(f"Renaming test '{test.name}' to '{test.name} {test.id}'")
+                test.name = f"{test.name} {test.id}"
+
+        for child_suite in suite.suites:
+            for test in child_suite.tests:
+                if test.name in self.test_names and self.test_names[test.name] > 1:
+                    logger.debug(
+                        f"Renaming test '{test.name}' to '{test.name} {test.id}'"
+                    )
+                    test.name = f"{test.name} {test.id}"

--- a/tests/unittests/core/html/test_result_writer.py
+++ b/tests/unittests/core/html/test_result_writer.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+from unittest.mock import create_autospec, patch
+
+import pytest
+from robot.model.testcase import TestCase
+from robot.model.testsuite import TestSuite
+
+from result_companion.core.html.result_writer import create_base_llm_result_log
+from result_companion.core.results.visitors import UniqueNameResultVisitor
+
+
+class DummyResult:
+    """A dummy ExecutionResult-like object for testing."""
+
+    def __init__(self, suite):
+        self.suite = suite
+
+    def visit(self, visitor: UniqueNameResultVisitor):
+        # Simulate traversing the suite: call start_test on each test and then end_suite on the suite.
+        for test in self.suite.tests:
+            visitor.start_test(test)
+        visitor.end_suite(self.suite)
+
+
+@pytest.fixture
+def dummy_result():
+    test1 = create_autospec(TestCase)
+    test1.name = "Test 1"
+    test1.id = "T1"
+
+    test2 = create_autospec(TestCase)
+    test2.name = "Test 2"
+    test2.id = "T2"
+    suite = TestSuite("Dummy Suite")
+    suite.tests = [test1, test2]
+    return DummyResult(suite)
+
+
+def test_write_log_with_llm_result_as_html_log_file(dummy_result):
+    dummy_input = Path("dummy_input.xml")
+    dummy_output = Path("dummy_output.html")
+
+    with patch(
+        "result_companion.core.html.result_writer.ExecutionResult",
+        return_value=dummy_result,
+    ) as mock_exec_result:
+        with patch(
+            "result_companion.core.html.result_writer.LLMResultWriter.write_results"
+        ) as mock_write_results:
+
+            # Call the function under test.
+            create_base_llm_result_log(dummy_input, dummy_output)
+
+            mock_exec_result.assert_called_once_with(dummy_input)
+            mock_write_results.assert_called_once()
+            args, kwargs = mock_write_results.call_args
+            # Check that the "log" keyword argument is equal to dummy_output.
+            assert kwargs.get("log") == dummy_output
+
+    tests = dummy_result.suite.tests
+    assert tests[0].name == "Test 1"
+    assert tests[1].name == "Test 2"

--- a/tests/unittests/core/parsers/test_result_parser.py
+++ b/tests/unittests/core/parsers/test_result_parser.py
@@ -1,5 +1,4 @@
 from result_companion.core.parsers.result_parser import (
-    add_unique_sufix_for_test_cases_with_duplicated_names,
     remove_redundant_fields,
     search_for_test_caseses,
 )
@@ -207,21 +206,3 @@ def test_removing_redundant_fields():
         "name": "Ollama Local Model Run Should Succede",
         "status": "FAIL",
     }
-
-
-def test_adding_unique_sufix_to_test_cases_with_duplicated_names():
-    data = [
-        {"name": "Test Case 1"},
-        {"name": "Test Case 1"},
-        {"name": "Test Case 2"},
-        {"name": "Test Case 2"},
-        {"name": "Unique Name"},
-    ]
-    result = add_unique_sufix_for_test_cases_with_duplicated_names(
-        data, random_sufix="123"
-    )
-    assert result[0] == {"name": "Test Case 1_123"}
-    assert result[1] == {"name": "Test Case 1_123"}
-    assert result[2] == {"name": "Test Case 2_123"}
-    assert result[3] == {"name": "Test Case 2_123"}
-    assert result[4] == {"name": "Unique Name"}

--- a/tests/unittests/core/parsers/test_result_parser.py
+++ b/tests/unittests/core/parsers/test_result_parser.py
@@ -1,4 +1,5 @@
 from result_companion.core.parsers.result_parser import (
+    add_unique_sufix_for_test_cases_with_duplicated_names,
     remove_redundant_fields,
     search_for_test_caseses,
 )
@@ -206,3 +207,21 @@ def test_removing_redundant_fields():
         "name": "Ollama Local Model Run Should Succede",
         "status": "FAIL",
     }
+
+
+def test_adding_unique_sufix_to_test_cases_with_duplicated_names():
+    data = [
+        {"name": "Test Case 1"},
+        {"name": "Test Case 1"},
+        {"name": "Test Case 2"},
+        {"name": "Test Case 2"},
+        {"name": "Unique Name"},
+    ]
+    result = add_unique_sufix_for_test_cases_with_duplicated_names(
+        data, random_sufix="123"
+    )
+    assert result[0] == {"name": "Test Case 1_123"}
+    assert result[1] == {"name": "Test Case 1_123"}
+    assert result[2] == {"name": "Test Case 2_123"}
+    assert result[3] == {"name": "Test Case 2_123"}
+    assert result[4] == {"name": "Unique Name"}

--- a/tests/unittests/core/results/test_visitors.py
+++ b/tests/unittests/core/results/test_visitors.py
@@ -1,0 +1,47 @@
+from unittest.mock import create_autospec
+
+from robot.model.testcase import TestCase
+from robot.model.testsuite import TestSuite
+
+from result_companion.core.results.visitors import UniqueNameResultVisitor
+
+
+def test_rename_duplicate_test_names():
+    """Test that the visitor renames tests with duplicate names by appending their ID."""
+    visitor = UniqueNameResultVisitor()
+
+    test1 = create_autospec(TestCase)
+    test1.name = "Duplicate Test"
+    test1.id = "s1-t1"
+
+    test2 = create_autospec(TestCase)
+    test2.name = "Duplicate Test"
+    test2.id = "s1-t2"
+
+    test3 = create_autospec(TestCase)
+    test3.name = "Unique Test"
+    test3.id = "s1-t3"
+
+    test4 = create_autospec(TestCase)
+    test4.name = "Duplicate Test"
+    test4.id = "s2-t1"
+
+    # Create real test suites
+    main_suite = TestSuite(name="Main Suite")
+    child_suite = TestSuite(name="Child Suite")
+
+    # Add tests to suites
+    main_suite.tests = [test1, test2, test3]
+    child_suite.tests = [test4]
+    main_suite.suites = [child_suite]
+
+    visitor.start_test(test1)
+    visitor.start_test(test2)
+    visitor.start_test(test3)
+    visitor.start_test(test4)
+    visitor.end_suite(main_suite)
+
+    assert test1.name == "Duplicate Test s1-t1"
+    assert test2.name == "Duplicate Test s1-t2"
+    assert test3.name == "Unique Test"  # Should remain unchanged
+    assert test4.name == "Duplicate Test s2-t1"


### PR DESCRIPTION
It is a workaround to fix situation when there are multiple test cases called the same and they are impossible to locate in log file based on its name only.