### PR TITLE
Helper for app state under ~/.result-companion/ (not inside the package)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.14] - 2026-04-05
+
+### Added
+- User state under `~/.result-companion` (create on first use): `get_or_create_current_user_rc_state_dir()`, nested dirs via `get_or_create_rc_state_subdirectory(*parts)` with `CLI` / `APP` — exported from `result_companion` / `result_companion.core.state_dir`
+
+[0.0.14]: https://github.com/miltroj/result-companion/releases/tag/v0.0.14
+
 ## [0.0.13] - 2026-04-04
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ test-unit:  ## Run unit tests
 test-integration:  ## Run integration tests
 	poetry run pytest -vv tests/integration/
 
-test-coverage:  ## Run unit tests with coverage
-	poetry run pytest --cov=result_companion --cov-report=term-missing tests/unittests
+test-coverage:  ## Run unit tests with coverage (terminal + htmlcov/index.html)
+	poetry run pytest --cov=result_companion --cov-report=term-missing --cov-report=html tests/unittests
 
 test-e2e:  ## Run e2e tests (require real Copilot CLI / Ollama)
 	poetry run pytest -vv tests/integration/ -m e2e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "result-companion"
-version = "0.0.13"
+version = "0.0.14"
 description = "AI-powered analysis of Robot Framework test failures - instant insights from output.xml"
 authors = ["Milosz Trojanowski <mil.troj@gmail.com>"]
 license = "Apache-2.0"

--- a/result_companion/__init__.py
+++ b/result_companion/__init__.py
@@ -8,3 +8,6 @@ except Exception:  # pragma: no cover
     __version__ = "0.0.0"
 
 from result_companion.api import analyze, review, run_analysis  # noqa: E402, F401
+from result_companion.core.state_dir import (  # noqa: E402, F401
+    get_or_create_current_user_rc_state_dir,
+)

--- a/result_companion/__init__.py
+++ b/result_companion/__init__.py
@@ -9,5 +9,8 @@ except Exception:  # pragma: no cover
 
 from result_companion.api import analyze, review, run_analysis  # noqa: E402, F401
 from result_companion.core.state_dir import (  # noqa: E402, F401
+    APP,
+    CLI,
     get_or_create_current_user_rc_state_dir,
+    get_or_create_rc_state_subdirectory,
 )

--- a/result_companion/core/state_dir.py
+++ b/result_companion/core/state_dir.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+_STATE_DIR_NAME = ".result-companion"
+
+
+def get_or_create_current_user_rc_state_dir(home: Path | None = None) -> Path:
+    """Returns the durable user state directory, creating it on first use.
+
+    Use this path for configs and artifacts so they survive pip installs and
+    updates. Extension packages depending on result-companion should import this
+    function rather than hardcoding a location.
+
+    Args:
+        home: Optional home directory; defaults to ``Path.home()`` for normal use.
+
+    Returns:
+        Absolute path to the state directory (e.g. ``~/.result-companion``).
+    """
+    root = home if home is not None else Path.home()
+    path = root / _STATE_DIR_NAME
+    path.mkdir(parents=True, exist_ok=True)
+    return path

--- a/result_companion/core/state_dir.py
+++ b/result_companion/core/state_dir.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 _STATE_DIR_NAME = ".result-companion"
 
+CLI = "cli"
+APP = "app"
+
 
 def get_or_create_current_user_rc_state_dir(home: Path | None = None) -> Path:
     """Returns the durable user state directory, creating it on first use.
@@ -18,5 +21,27 @@ def get_or_create_current_user_rc_state_dir(home: Path | None = None) -> Path:
     """
     root = home if home is not None else Path.home()
     path = root / _STATE_DIR_NAME
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def get_or_create_rc_state_subdirectory(*parts: str, home: Path | None = None) -> Path:
+    """Returns a directory under ``~/.result-companion``, creating it if missing.
+
+    Same root as ``get_or_create_current_user_rc_state_dir``; ``parts`` are extra
+    folders (e.g. ``CLI``, or ``CLI`` + ``"data"``). Do not pass file names—use
+    ``get_or_create_rc_state_subdirectory(CLI) / "config.yaml"`` for files.
+
+    Args:
+        *parts: Directory segments relative to the RC state root.
+        home: Optional home directory for tests.
+
+    Returns:
+        Absolute path to that directory (the state root if ``parts`` is empty).
+    """
+    base = get_or_create_current_user_rc_state_dir(home=home)
+    if not parts:
+        return base
+    path = base.joinpath(*parts)
     path.mkdir(parents=True, exist_ok=True)
     return path

--- a/tests/unittests/core/test_state_dir.py
+++ b/tests/unittests/core/test_state_dir.py
@@ -2,7 +2,12 @@
 
 from pathlib import Path
 
-from result_companion.core.state_dir import get_or_create_current_user_rc_state_dir
+from result_companion.core.state_dir import (
+    APP,
+    CLI,
+    get_or_create_current_user_rc_state_dir,
+    get_or_create_rc_state_subdirectory,
+)
 
 
 def test_get_user_state_dir_creates_directory_under_home(tmp_path: Path) -> None:
@@ -17,3 +22,19 @@ def test_get_user_state_dir_second_call_reuses_existing(tmp_path: Path) -> None:
     second = get_or_create_current_user_rc_state_dir(home=tmp_path)
 
     assert first == second
+
+
+def test_get_or_create_rc_state_subdirectory_cli_and_data(tmp_path: Path) -> None:
+    cli = get_or_create_rc_state_subdirectory(CLI, home=tmp_path)
+    data = get_or_create_rc_state_subdirectory(CLI, "data", home=tmp_path)
+
+    assert cli == tmp_path / ".result-companion" / "cli"
+    assert data == cli / "data"
+    assert cli.is_dir() and data.is_dir()
+
+
+def test_get_or_create_rc_state_subdirectory_app_segment(tmp_path: Path) -> None:
+    app_dir = get_or_create_rc_state_subdirectory(APP, home=tmp_path)
+
+    assert app_dir == tmp_path / ".result-companion" / APP
+    assert app_dir.is_dir()

--- a/tests/unittests/core/test_state_dir.py
+++ b/tests/unittests/core/test_state_dir.py
@@ -1,0 +1,19 @@
+"""Tests for durable user state directory."""
+
+from pathlib import Path
+
+from result_companion.core.state_dir import get_or_create_current_user_rc_state_dir
+
+
+def test_get_user_state_dir_creates_directory_under_home(tmp_path: Path) -> None:
+    state = get_or_create_current_user_rc_state_dir(home=tmp_path)
+
+    assert state == tmp_path / ".result-companion"
+    assert state.is_dir()
+
+
+def test_get_user_state_dir_second_call_reuses_existing(tmp_path: Path) -> None:
+    first = get_or_create_current_user_rc_state_dir(home=tmp_path)
+    second = get_or_create_current_user_rc_state_dir(home=tmp_path)
+
+    assert first == second

--- a/tests/unittests/core/test_state_dir.py
+++ b/tests/unittests/core/test_state_dir.py
@@ -24,6 +24,13 @@ def test_get_user_state_dir_second_call_reuses_existing(tmp_path: Path) -> None:
     assert first == second
 
 
+def test_get_or_create_rc_state_subdirectory_no_parts_is_state_root(
+    tmp_path: Path,
+) -> None:
+    root = get_or_create_current_user_rc_state_dir(home=tmp_path)
+    assert get_or_create_rc_state_subdirectory(home=tmp_path) == root
+
+
 def test_get_or_create_rc_state_subdirectory_cli_and_data(tmp_path: Path) -> None:
     cli = get_or_create_rc_state_subdirectory(CLI, home=tmp_path)
     data = get_or_create_rc_state_subdirectory(CLI, "data", home=tmp_path)


### PR DESCRIPTION
Add global state directory for future persistance