### PR TITLE
#68 fix(html on windows): use explicit utf-8 encoding in HTML injection r…

### DIFF
--- a/result_companion/core/html/html_creator.py
+++ b/result_companion/core/html/html_creator.py
@@ -160,5 +160,7 @@ $(function() {
 });
 </script>
 """
-    html = html_path.read_text()
-    html_path.write_text(html.replace("</body>", f"{script}\n</body>"))
+    html = html_path.read_text(encoding="utf-8")
+    html_path.write_text(
+        html.replace("</body>", f"{script}\n</body>"), encoding="utf-8"
+    )

--- a/tests/unittests/core/html/test_html_creator.py
+++ b/tests/unittests/core/html/test_html_creator.py
@@ -1,6 +1,7 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from result_companion.core.html.html_creator import create_llm_html_log
+from result_companion.core.html.html_creator import _inject_llm_ui, create_llm_html_log
 
 
 @patch(
@@ -38,3 +39,18 @@ def test_create_llm_html_log(
     injected_html = mock_write.call_args[0][0]
     assert "AI Analysis" in injected_html
     assert "</body>" in injected_html
+
+
+def test_inject_llm_ui_uses_utf8_encoding_and_injects_script_before_body(
+    tmp_path: Path,
+) -> None:
+    """Script is injected before </body> and file round-trips correctly under UTF-8."""
+    html_file = tmp_path / "log.html"
+    html_file.write_text("<html><body>résumé</body></html>", encoding="utf-8")
+
+    _inject_llm_ui(html_file)
+
+    result = html_file.read_text(encoding="utf-8")
+    assert "AI Analysis" in result
+    assert result.index("AI Analysis") < result.index("</body>")
+    assert "résumé" in result


### PR DESCRIPTION
## What

- `read_text`/`write_text` without explicit encoding fails on Windows locales (e.g. cp1252) when processing the UTF-8 Robot Framework HTML log
- Adds `encoding="utf-8"` to both calls in `_inject_llm_ui`

## Changed files

`result_companion/core/html/html_creator.py`

## Test plan

- [x] Run `result-companion analyze` on Windows without `PYTHONUTF8=1` and verify no `UnicodeDecodeError`

Closes #68